### PR TITLE
Missing number of channels in WAV encoding

### DIFF
--- a/lib/WavAudioEncoder.js
+++ b/lib/WavAudioEncoder.js
@@ -41,7 +41,7 @@
     view.setUint16(20, 1, true);
     view.setUint16(22, this.numChannels, true);
     view.setUint32(24, this.sampleRate, true);
-    view.setUint32(28, this.sampleRate * 4, true);
+    view.setUint32(28, this.sampleRate * this.numChannels * 2, true);
     view.setUint16(32, this.numChannels * 2, true);
     view.setUint16(34, 16, true);
     setString(view, 36, 'data');


### PR DESCRIPTION
The WAV encoding is missing the number of channels when writing the headers. It assumes the channels are always 2.